### PR TITLE
Use native execFileSync only (Node 0.11+)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var childProcess = require('child_process');
-var execFileSync = require('exec-file-sync');
+var execFileSync = childProcess.execFileSync;
 var lcid = require('lcid');
 var cache;
 
@@ -75,7 +75,7 @@ module.exports = function (cb) {
 };
 
 module.exports.sync = function () {
-	if (cache || getEnvLocale()) {
+	if (cache || getEnvLocale() || !execFileSync) {
 		return cache;
 	}
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "region"
   ],
   "dependencies": {
-    "exec-file-sync": "^2.0.0",
     "lcid": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
As suggested in [PR 10](https://github.com/sindresorhus/os-locale/pull/10#issuecomment-136675388), replace the `exec-file-sync` ponyfill to avoid problematic postinstall script from `spawn-sync` transitive dependency. This means the `sync()` method will only use environment variables for Node 0.10 or lower.

Successfully tested with:
- Node 0.10.40
- Node 0.11.16
- Node 0.12.7
- iojs 3.2.0