### PR TITLE
Fix locale variable resolution order

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,14 +12,18 @@ function fallback() {
 
 function getEnvLocale() {
 	var env = process.env;
-	var ret = env.LC_ALL || env.LANGUAGE || env.LANG || env.LC_MESSAGES;
+	var ret = env.LC_ALL || env.LC_MESSAGES || env.LANG || env.LANGUAGE;
 	cache = getLocale(ret);
 	return ret;
 }
 
 function parseLocale(x) {
-	var res = /(?:LC_ALL|LANG|LC_MESSAGES|LC_CTYPE|)="([^"]{2,})"/.exec(x);
-	return res && res[1];
+	var env = x.split('\n').reduce(function (env, def) {
+		def = def.split('=')
+		env[def[0]] = def[1]
+		return env
+	}, {})
+	return getEnvLocale(env)
 }
 
 function getLocale(str) {

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,12 @@
 # os-locale [![Build Status](https://travis-ci.org/sindresorhus/os-locale.svg?branch=master)](https://travis-ci.org/sindresorhus/os-locale)
 
-> Get the system [locale](http://en.wikipedia.org/wiki/Locale)
+Get the system [locale](http://en.wikipedia.org/wiki/Locale).
 
 Useful for localizing your module or app.
+
+POSIX systems: The returned locale refers to the `LC_MESSAGE`
+category, suitable for selecting the language used in the user
+interface for message translation.
 
 
 ## Install


### PR DESCRIPTION
- LC_MESSAGES have precedence over LANG

- `LANGUAGE` is used as the last option

- Put output of `locale(1)` to the same rules of environment
  variable parsing

`gettext` uses `LANGUAGE` as the first option, but **only if**
the locale is set properly, this implementation only uses
LANGUAGE if no other variable is set.

Also, this patch adds a note to the README so users can notice
that the returned locale in POSIX systems is useful for
translations only.