### PR TITLE
Implement Promise interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
+  - '6'
   - '4'
-  - '0.12'
-  - '0.10'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava"
@@ -33,7 +33,9 @@
     "region"
   ],
   "dependencies": {
-    "lcid": "^1.0.0"
+    "execa": "^0.5.0",
+    "lcid": "^1.0.0",
+    "mem": "^1.1.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ $ npm install --save os-locale
 ```js
 var osLocale = require('os-locale');
 
-osLocale(function (err, locale) {
+osLocale.then(locale => {
 	console.log(locale);
 	//=> 'en_US'
 });
@@ -28,7 +28,9 @@ osLocale(function (err, locale) {
 
 ## API
 
-### osLocale([options], callback(error, locale))
+### osLocale([options])
+
+Returns a promise for the locale.
 
 ### osLocale.sync([options])
 

--- a/test.js
+++ b/test.js
@@ -22,20 +22,11 @@ function restoreEnvVars(cache) {
 	});
 }
 
-test.cb('async', t => {
-	t.plan(2);
-
-	requireUncached('./')()
-		.then(locale => {
-			console.log('Locale identifier:', locale);
-			t.true(locale.length > 1);
-			t.not(locale.indexOf('_'), -1);
-			t.end();
-		})
-		.catch(() => {
-			t.false('Promise rejected');
-			t.end();
-		});
+test('async', async t => {
+	const locale = await requireUncached('./')();
+	console.log('Locale identifier:', locale);
+	t.true(locale.length > 1);
+	t.not(locale.indexOf('_'), -1);
 });
 
 test('sync', t => {
@@ -45,9 +36,7 @@ test('sync', t => {
 	t.not(locale.indexOf('_'), -1);
 });
 
-test.cb.serial('async without spawn', t => {
-	t.plan(2);
-
+test('async without spawn', async t => {
 	const beforeTest = {};
 
 	// unset env vars and cache for restoration
@@ -64,33 +53,24 @@ test.cb.serial('async without spawn', t => {
 	};
 
 	// test async method
-	requireUncached('./')({spawn: false})
-		.then(locale => {
-			console.log('Locale identifier:', locale);
-			afterTest();
-			t.is(locale, expectedFallback, 'Locale did not match expected fallback');
-			t.not(locale, 'spawn_NOTALLOWED', 'Attempted to spawn subprocess');
-			t.end();
-		})
-		.catch(() => {
-			t.false('Promise rejected');
-			t.end();
-		});
+	const locale = await requireUncached('./')({spawn: false});
+	console.log('Locale identifier:', locale);
+	afterTest();
+	t.is(locale, expectedFallback, 'Locale did not match expected fallback');
+	t.not(locale, 'spawn_NOTALLOWED', 'Attempted to spawn subprocess');
 });
 
-test.serial('sync without spawn', t => {
+test('sync without spawn', t => {
 	const beforeTest = {};
 
 	// unset env vars and cache for restoration
 	unsetEnvVars(beforeTest);
 
 	// mock execa.sync
-	if (execa.sync) {
-		beforeTest.execaSync = execa.sync;
-		execa.sync = () => {
-			t.false('Attempted to spawn subprocess');
-		};
-	}
+	beforeTest.execaSync = execa.sync;
+	execa.sync = () => {
+		t.false('Attempted to spawn subprocess');
+	};
 
 	// test sync method
 	const locale = requireUncached('./').sync({spawn: false});


### PR DESCRIPTION
As mentioned in #20 .

```cache``` global removed. Using [```mem```](https://github.com/sindresorhus/mem) to cache return values.

[```execa```](https://github.com/sindresorhus/execa) being used instead of ```child_process ```.


#### getLocale regex

The regex was updated.

The system's ```locale``` command returns a set of lines like:
```
...
LC_COLLATE="en_GB.UTF-8"
LC_CTYPE="en_GB.UTF-8"
LC_MESSAGES="en_GB.UTF-8"
...
```

Each line is split by the ```=``` sign.

Given the string ```"en_GB.UTF-8"```,  replace would return ```"en_GB```.


```javascript
str = "\"en_GB.UTF-8\"";

str.replace(/[.:].*/, ''); // returns "en_GB
str.replace(/["]?(.*)[.:].*/, '$1'); // returns en_GB
```