### PR TITLE
Fix of not detecting language on OS X

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function fallback() {
 function getEnvLocale(env) {
 	env = env || process.env;
 	var ret = env.LC_ALL || env.LC_MESSAGES || env.LANG || env.LANGUAGE;
+	if(process.platform == "darwin" && env.LANG == "") return false;
 	cache = getLocale(ret);
 	return ret;
 }


### PR DESCRIPTION
Apps launched from Dock, or as packaged in standalone app (Electron), process.env variable doesnt contains a LANG variable (and many others variables), so its needed to force the detect via spawn. 