### PR TITLE
Update execa to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "region"
   ],
   "dependencies": {
-    "execa": "^0.6.3",
+    "execa": "^0.7.0",
     "lcid": "^1.0.0",
     "mem": "^1.1.0"
   },


### PR DESCRIPTION
I want to reduce node_modules size — yargs depends on os-locale, but os-locale uses old version of execa.