### PR TITLE
Validate `AppleLocale` against supported locales

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,12 +24,30 @@ function getLocale(string) {
 	return (string && string.replace(/[.:].*/, ''));
 }
 
+function getLocales() {
+	return execa.stdout('locale', ['-a']);
+}
+
+function getLocalesSync() {
+	return execa.sync('locale', ['-a']).stdout;
+}
+
+function getSupportedLocale(locale, locales = '') {
+	return locales.indexOf(locale) !== -1 ? locale : defaultLocale
+}
+
 function getAppleLocale() {
-	return execa.stdout('defaults', ['read', '-g', 'AppleLocale']);
+	return Promise.all(
+		execa.stdout('defaults', ['read', '-g', 'AppleLocale']),
+		getLocales(),
+	).then(results => getSupportedLocale(results[0], results[1]))
 }
 
 function getAppleLocaleSync() {
-	return execa.sync('defaults', ['read', '-g', 'AppleLocale']).stdout;
+	return getSupportedLocale(
+		execa.sync('defaults', ['read', '-g', 'AppleLocale']).stdout,
+		getLocalesSync()
+	)
 }
 
 function getUnixLocale() {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function getSupportedLocale(locale, locales = '') {
 
 function getAppleLocale() {
 	return Promise.all([
-		execa.stdout('defaults', ['read', '-g', 'AppleLocale']),
+		execa.stdout('defaults', ['read', '-globalDomain', 'AppleLocale']),
 		getLocales()
 	]).then(results => getSupportedLocale(results[0], results[1]));
 }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function getLocalesSync() {
 }
 
 function getSupportedLocale(locale, locales = '') {
-	return locales.indexOf(locale) === -1 ? defaultLocale : locale;
+	return locales.includes(locale) ? locale : defaultLocale;
 }
 
 function getAppleLocale() {

--- a/index.js
+++ b/index.js
@@ -33,21 +33,21 @@ function getLocalesSync() {
 }
 
 function getSupportedLocale(locale, locales = '') {
-	return locales.indexOf(locale) !== -1 ? locale : defaultLocale
+	return locales.indexOf(locale) === -1 ? defaultLocale : locale;
 }
 
 function getAppleLocale() {
-	return Promise.all(
+	return Promise.all([
 		execa.stdout('defaults', ['read', '-g', 'AppleLocale']),
-		getLocales(),
-	).then(results => getSupportedLocale(results[0], results[1]))
+		getLocales()
+	]).then(results => getSupportedLocale(results[0], results[1]));
 }
 
 function getAppleLocaleSync() {
 	return getSupportedLocale(
 		execa.sync('defaults', ['read', '-g', 'AppleLocale']).stdout,
 		getLocalesSync()
-	)
+	);
 }
 
 function getUnixLocale() {


### PR DESCRIPTION
Fixes #28, zeit/hyper#3091, and https://github.com/zeit/hyper/pull/2913#issuecomment-447627297.

MacOS `defaults read -g AppleLocale` returns invalid POSIX values when the locale is different than language, causing values like `en_DE` or `en_IR`. Fortunately, we also have `/usr/bin/locale -a` which returns a list of supported locales.

This PR fixes issue, by validating locale against supporting locales and falling back to the `defaultLocale` in case of invalid one.

--- 

Attachment. Perl warning:

```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LC_ALL = (unset),
        LANG = "en_DE.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
```