### PR TITLE
Patch 2.1.0 to have mem@4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "execa": "^0.7.0",
     "lcid": "^1.0.0",
-    "mem": "^1.1.0"
+    "mem": "^4.0.0"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
I have a dependency tree which depends on `^2.1.0 ` of this project and I see you have patched this in the latest version but it would be great if you could also patch the lower version of this so I can pick it up stream without having to have dependency in the tree adopt major version changes. The issue is a security issue but also a memory leak, so its not great.

I think this should not be applied to master but a currently non-existent `v2.1.x` branch and then ideally be deploy as `v2.1.1` of this package. That would cause it to get picked up upstream for a lot of people.

Here is the current dependency tree:

```
├─┬ mjml@4.4.0-beta.2
│ ├─┬ mjml-cli@4.4.0-beta.2
│ │ └─┬ yargs@8.0.2
│ │   ├─┬ os-locale@2.1.0
│ │   │ └─┬ mem@1.1.0
```

Actual Security Alert
<img width="788" alt="Screen Shot 2019-08-13 at 2 46 49 PM" src="https://user-images.githubusercontent.com/10974/62972260-3a966b00-bdd9-11e9-919e-b657543b5e97.png">