### PR TITLE
Upgrade `execa` to v4 and require Node.js 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const defaultOptions = {spawn: true};
 const defaultLocale = 'en-US';
 
 async function getStdOut(command, args) {
-	return execa.stdout(command, args);
+	return (await execa(command, args)).stdout;
 }
 
 function getStdOutSync(command, args) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -34,7 +34,7 @@
 		"region"
 	],
 	"dependencies": {
-		"execa": "^1.0.0",
+		"execa": "^4.0.0",
 		"lcid": "^3.0.0",
 		"mem": "^5.0.0"
 	},

--- a/test.js
+++ b/test.js
@@ -5,18 +5,18 @@ const proxyquire = proxyquireBase.noPreserveCache().noCallThru();
 
 const expectedFallback = 'en-US';
 
-const noExeca = t => ({
-	stdout: async () => t.fail('Execa should not be called'),
-	sync: () => t.fail('Execa should not be called')
-});
+const noExeca = t => {
+	const fn = () => t.fail('Execa should not be called');
+	fn.stdout = async () => t.fail('Execa should not be called');
+
+	return fn;
+};
 
 const syncExeca = callback => ({
 	sync: (...args) => ({stdout: callback(...args)})
 });
 
-const asyncExeca = callback => ({
-	stdout: async (...args) => callback(...args)
-});
+const asyncExeca = callback => async (...args) => ({stdout: callback(...args)});
 
 const setPlatform = platform => {
 	Object.defineProperty(process, 'platform', {value: platform});


### PR DESCRIPTION
Since Node v8 is being sunset at the end of the year, used this opportunity to jump on latest execa.