### PR TITLE
Drop `execa` dependency

### DIFF
--- a/execa.js
+++ b/execa.js
@@ -3,13 +3,29 @@
 const {promisify} = require('util');
 const childProcess = require('child_process');
 
-module.exports = promisify(childProcess.execFile).then(value => {
-	value.stdout = value.stdout.trim();
-	return value;
-});
+const execFile = promisify(childProcess.execFile);
 
-module.exports.sync = () => {
-	const value = childProcess.sync();
-	value.stdout = value.stdout.trim();
-	return value;
-};
+/**
+@param  {string} command
+@param  {string[]} args
+
+@returns Promise<import('child_process').ChildProcess>
+*/
+async function execa(command, args) {
+	const child = await execFile(command, args, {encoding: 'utf-8'});
+	child.stdout = child.stdout.trim();
+	return child;
+}
+
+/**
+@param  {string} command
+@param  {string[]} args
+
+@returns string
+*/
+function execaSync(command, args) {
+	return childProcess.execFileSync(command, args, {encoding: 'utf-8'}).trim();
+}
+
+module.exports = execa;
+module.exports.sync = execaSync;

--- a/execa.js
+++ b/execa.js
@@ -1,0 +1,15 @@
+// Mini wrapper around child_process to make it behave a little like execa
+
+const {promisify} = require('util');
+const childProcess = require('child_process');
+
+module.exports = promisify(childProcess.execFile).then(value => {
+	value.stdout = value.stdout.trim();
+	return value;
+});
+
+module.exports.sync = () => {
+	const value = childProcess.sync();
+	value.stdout = value.stdout.trim();
+	return value;
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const execa = require('./execa');
+const execa = require('./execa.js');
 const lcid = require('lcid');
 
 const defaultOptions = {spawn: true};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const execa = require('execa');
+const execa = require('./execa');
 const lcid = require('lcid');
 const mem = require('mem');
 

--- a/test.js
+++ b/test.js
@@ -5,6 +5,8 @@ const proxyquire = proxyquireBase.noPreserveCache().noCallThru();
 
 const expectedFallback = 'en-US';
 
+const execaImport = './execa';
+
 const noExeca = t => {
 	const fn = () => t.fail('Execa should not be called');
 	fn.stdout = async () => t.fail('Execa should not be called');
@@ -48,7 +50,7 @@ test.serial('Async retrieve locale from LC_ALL env as 1st priority', async t => 
 	process.env.LC_MESSAGES = 'en-GB3';
 	process.env.LC_ALL = 'en-GB4';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)})();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)})();
 
 	t.is(locale, 'en-GB4');
 });
@@ -58,7 +60,7 @@ test.serial('Async retrieve locale from LC_MESSAGES env as 2st priority', async 
 	process.env.LANG = 'en-GB2';
 	process.env.LC_MESSAGES = 'en-GB3';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)})();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)})();
 
 	t.is(locale, 'en-GB3');
 });
@@ -67,7 +69,7 @@ test.serial('Async retrieve locale from LANG env as 3st priority', async t => {
 	process.env.LANGUAGE = 'en-GB1';
 	process.env.LANG = 'en-GB2';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)})();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)})();
 
 	t.is(locale, 'en-GB2');
 });
@@ -75,7 +77,7 @@ test.serial('Async retrieve locale from LANG env as 3st priority', async t => {
 test.serial('Async retrieve locale from LANGUAGE env as 4st priority', async t => {
 	process.env.LANGUAGE = 'en-GB1';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)})();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)})();
 
 	t.is(locale, 'en-GB1');
 });
@@ -86,7 +88,7 @@ test.serial('Sync retrieve locale from LC_ALL env as 1st priority', async t => {
 	process.env.LC_MESSAGES = 'en-GB3';
 	process.env.LC_ALL = 'en-GB4';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)}).sync();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)}).sync();
 
 	t.is(locale, 'en-GB4');
 });
@@ -96,7 +98,7 @@ test.serial('Sync retrieve locale from LC_MESSAGES env as 2st priority', async t
 	process.env.LANG = 'en-GB2';
 	process.env.LC_MESSAGES = 'en-GB3';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)}).sync();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)}).sync();
 
 	t.is(locale, 'en-GB3');
 });
@@ -105,7 +107,7 @@ test.serial('Sync retrieve locale from LANG env as 3st priority', async t => {
 	process.env.LANGUAGE = 'en-GB1';
 	process.env.LANG = 'en-GB2';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)}).sync();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)}).sync();
 
 	t.is(locale, 'en-GB2');
 });
@@ -113,7 +115,7 @@ test.serial('Sync retrieve locale from LANG env as 3st priority', async t => {
 test.serial('Sync retrieve locale from LANGUAGE env as 4st priority', async t => {
 	process.env.LANGUAGE = 'en-GB1';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)}).sync();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)}).sync();
 
 	t.is(locale, 'en-GB1');
 });
@@ -121,7 +123,7 @@ test.serial('Sync retrieve locale from LANGUAGE env as 4st priority', async t =>
 test.serial('Async normalises locale', async t => {
 	process.env.LC_ALL = 'en_GB';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)})();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)})();
 
 	t.is(locale, 'en-GB');
 });
@@ -129,19 +131,19 @@ test.serial('Async normalises locale', async t => {
 test.serial('Sync normalises locale', async t => {
 	process.env.LC_ALL = 'en_GB';
 
-	const locale = await proxyquire('.', {execa: noExeca(t)}).sync();
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)}).sync();
 
 	t.is(locale, 'en-GB');
 });
 
 test.serial('Async fallback locale when env variables missing and spawn=false ', async t => {
-	const locale = await proxyquire('.', {execa: noExeca(t)})({spawn: false});
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)})({spawn: false});
 
 	t.is(locale, expectedFallback, 'Locale did not match expected fallback');
 });
 
 test.serial('Sync fallback locale when env variables missing and spawn=false ', async t => {
-	const locale = await proxyquire('.', {execa: noExeca(t)}).sync({spawn: false});
+	const locale = await proxyquire('.', {[execaImport]: noExeca(t)}).sync({spawn: false});
 
 	t.is(locale, expectedFallback, 'Locale did not match expected fallback');
 });
@@ -150,7 +152,7 @@ test.serial('Async handle darwin locale ', async t => {
 	setPlatform('darwin');
 	const execa = asyncExeca(cmd => cmd === 'defaults' ? 'en-GB' : ['en-US', 'en-GB']);
 
-	const locale = await proxyquire('.', {execa})();
+	const locale = await proxyquire('.', {[execaImport]: execa})();
 
 	t.is(locale, 'en-GB');
 });
@@ -159,7 +161,7 @@ test.serial('Sync handle darwin locale ', async t => {
 	setPlatform('darwin');
 	const execa = syncExeca(cmd => cmd === 'defaults' ? 'en-GB' : ['en-US', 'en-GB']);
 
-	const locale = await proxyquire('.', {execa}).sync();
+	const locale = await proxyquire('.', {[execaImport]: execa}).sync();
 
 	t.is(locale, 'en-GB');
 });
@@ -168,7 +170,7 @@ test.serial('Async handle win32 locale ', async t => {
 	setPlatform('win32');
 	const execa = asyncExeca(() => 'Locale\n0809\n');
 
-	const locale = await proxyquire('.', {execa})();
+	const locale = await proxyquire('.', {[execaImport]: execa})();
 
 	t.is(locale, 'en-GB');
 });
@@ -177,7 +179,7 @@ test.serial('Sync handle win32 locale ', async t => {
 	setPlatform('win32');
 	const execa = syncExeca(() => 'Locale\n0809\n');
 
-	const locale = await proxyquire('.', {execa}).sync();
+	const locale = await proxyquire('.', {[execaImport]: execa}).sync();
 
 	t.is(locale, 'en-GB');
 });
@@ -193,7 +195,7 @@ LC_NUMERIC="en_GB"
 LC_TIME="en_GB"
 LC_ALL=en_GB`);
 
-	const locale = await proxyquire('.', {execa})();
+	const locale = await proxyquire('.', {[execaImport]: execa})();
 
 	t.is(locale, 'en-GB');
 });
@@ -209,7 +211,7 @@ LC_NUMERIC="en_GB"
 LC_TIME="en_GB"
 LC_ALL=en_GB`);
 
-	const locale = await proxyquire('.', {execa}).sync();
+	const locale = await proxyquire('.', {[execaImport]: execa}).sync();
 
 	t.is(locale, 'en-GB');
 });

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const proxyquire = proxyquireBase.noPreserveCache().noCallThru();
 
 const expectedFallback = 'en-US';
 
-const execaImport = './execa';
+const execaImport = './execa.js';
 
 const noExeca = t => {
 	const fn = () => t.fail('Execa should not be called');


### PR DESCRIPTION
- [x] Test it in a real project because the tests actually skip the new shim altogether

I know this is probably not something welcome, but I looked at the usage of `execa` and maybe it's not necessary here. It'd make `os-locale` quite small

<img width="1117" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/110292037-41379500-7fb2-11eb-8035-0ecb7d2c45eb.png">
