### PR TITLE
Drop `mem` dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,14 +69,14 @@ function getUnixLocaleSync() {
 
 async function getWinLocale() {
 	const stdout = await getStdOut('wmic', ['os', 'get', 'locale']);
-	const lcidCode = Number.parseInt(stdout.replace('Locale', ''), 16);
+	const lcidCode = parseInt(stdout.replace('Locale', ''), 16);
 
 	return lcid.from(lcidCode);
 }
 
 function getWinLocaleSync() {
 	const stdout = getStdOutSync('wmic', ['os', 'get', 'locale']);
-	const lcidCode = Number.parseInt(stdout.replace('Locale', ''), 16);
+	const lcidCode = parseInt(stdout.replace('Locale', ''), 16);
 
 	return lcid.from(lcidCode);
 }
@@ -107,14 +107,14 @@ module.exports = async (options = defaultOptions) => {
 		} else {
 			locale = await getUnixLocale();
 		}
-	} catch {}
+	} catch (_) {}
 
 	const normalised = normalise(locale || defaultLocale);
 	asyncCache.set(options.spawn, normalised);
 	return normalised;
 };
 
-const syncCache = new Map();
+const syncCache = {};
 
 module.exports.sync = (options = defaultOptions) => {
 	if (syncCache.has(options.spawn)) {
@@ -134,7 +134,7 @@ module.exports.sync = (options = defaultOptions) => {
 		} else {
 			locale = getUnixLocaleSync();
 		}
-	} catch {}
+	} catch (_) {}
 
 	const normalised = normalise(locale || defaultLocale);
 	syncCache.set(options.spawn, normalised);

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ module.exports = async (options = defaultOptions) => {
 	return normalised;
 };
 
-const syncCache = {};
+const syncCache = new Map();
 
 module.exports.sync = (options = defaultOptions) => {
 	if (syncCache.has(options.spawn)) {

--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function normalise(input) {
 	return input.replace(/_/, '-');
 }
 
-// Uses simple map as a simple memoization technique without having to import `mem`
+// Uses a map as a simple memoization technique without having to import `mem`
 const asyncCache = new Map();
 
 module.exports = async (options = defaultOptions) => {

--- a/index.js
+++ b/index.js
@@ -69,14 +69,14 @@ function getUnixLocaleSync() {
 
 async function getWinLocale() {
 	const stdout = await getStdOut('wmic', ['os', 'get', 'locale']);
-	const lcidCode = parseInt(stdout.replace('Locale', ''), 16);
+	const lcidCode = Number.parseInt(stdout.replace('Locale', ''), 16);
 
 	return lcid.from(lcidCode);
 }
 
 function getWinLocaleSync() {
 	const stdout = getStdOutSync('wmic', ['os', 'get', 'locale']);
-	const lcidCode = parseInt(stdout.replace('Locale', ''), 16);
+	const lcidCode = Number.parseInt(stdout.replace('Locale', ''), 16);
 
 	return lcid.from(lcidCode);
 }
@@ -85,11 +85,12 @@ function normalise(input) {
 	return input.replace(/_/, '-');
 }
 
-const asyncCache = {};
+// Uses simple map as a simple memoization technique without having to import `mem`
+const asyncCache = new Map();
 
 module.exports = async (options = defaultOptions) => {
-	if (asyncCache[options.spawn]) {
-		return asyncCache[options.spawn];
+	if (asyncCache.has(options.spawn)) {
+		return asyncCache.get(options.spawn);
 	}
 
 	let locale;
@@ -106,18 +107,18 @@ module.exports = async (options = defaultOptions) => {
 		} else {
 			locale = await getUnixLocale();
 		}
-	} catch (_) {}
+	} catch {}
 
 	const normalised = normalise(locale || defaultLocale);
-	asyncCache[options.spawn] = normalised;
+	asyncCache.set(options.spawn, normalised);
 	return normalised;
 };
 
-const syncCache = {};
+const syncCache = new Map();
 
 module.exports.sync = (options = defaultOptions) => {
-	if (syncCache[options.spawn]) {
-		return syncCache[options.spawn];
+	if (syncCache.has(options.spawn)) {
+		return syncCache.get(options.spawn);
 	}
 
 	let locale;
@@ -133,9 +134,9 @@ module.exports.sync = (options = defaultOptions) => {
 		} else {
 			locale = getUnixLocaleSync();
 		}
-	} catch (_) {}
+	} catch {}
 
 	const normalised = normalise(locale || defaultLocale);
-	syncCache[options.spawn] = normalised;
+	syncCache.set(options.spawn, normalised);
 	return normalised;
 };

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
 	],
 	"dependencies": {
 		"execa": "^4.0.0",
-		"lcid": "^3.0.0",
-		"mem": "^5.0.0"
+		"lcid": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",


### PR DESCRIPTION
I know this is probably not something welcome, but with just one option maybe it's not necessary here. Together with #46 it'd reduce `os-locale`’s dependencies from 26 to 2.

<img width="1117" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/110292037-41379500-7fb2-11eb-8035-0ecb7d2c45eb.png">
