### PR TITLE
fix: osLocaleSync get wrong locale because of execSync returns undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 node_modules
 yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.idea
 node_modules
 yarn.lock

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ async function getStdOut(command, args) {
 }
 
 function getStdOutSync(command, args) {
-	return execSync(command, args).stdout;
+	return execSync(command, args);
 }
 
 function getEnvLocale(env = process.env) {


### PR DESCRIPTION
Because the return value of `execSync` is a string, `execSync().stdout` will be `undefined`.

So, why not TypeScript? 🙃